### PR TITLE
Add support for TLS authentication

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -81,14 +81,18 @@ class DockerSpawner(Spawner):
         )
     )
 
-    tls = Bool(False, config=True, help="If True, use --tls")
-    tls_verify = Bool(False, config=True, help="If True, use --tlsverify")
-    tls_ca = Unicode("", config=True, help="Path to CA certificate")
-    tls_cert = Unicode("", config=True, help="Path to client certificate")
-    tls_key = Unicode("", config=True, help="Path to client key")
+    tls = Bool(False, config=True, help="If True, connect to docker with --tls")
+    tls_verify = Bool(False, config=True, help="If True, connect to docker with --tlsverify")
+    tls_ca = Unicode("", config=True, help="Path to CA certificate for docker TLS")
+    tls_cert = Unicode("", config=True, help="Path to client certificate for docker TLS")
+    tls_key = Unicode("", config=True, help="Path to client key for docker TLS")
 
     @property
     def tls_client(self):
+        """A tuple consisting of the TLS client certificate and key if they
+        have been provided, otherwise None.
+
+        """
         if self.tls_cert and self.tls_key:
             return (self.tls_cert, self.tls_key)
         return None

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -35,7 +35,6 @@ class DockerSpawner(Spawner):
         if cls._client is None:
             if self.tls:
                 tls_config = True
-                self.log.debug("Using --tls")
             elif self.tls_verify or self.tls_ca or self.tls_client:
                 tls_config = docker.tls.TLSConfig(
                     client_cert=self.tls_client,


### PR DESCRIPTION
This makes it possible to connect to the docker daemon using TLS authentication, which is necessary (for example) if the docker container being launched is being created on a different machine.