### PR TITLE
Docker args config

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -87,8 +87,8 @@ class DockerSpawner(Spawner):
     tls_key = Unicode("", config=True, help="Path to client key for docker TLS")
 
     remove_containers = Bool(False, config=True, help="If True, delete containers after they are stopped.")
-    extra_create_kwargs = Dict({}, config=True, help="Additional args to pass for container create")
-    extra_start_kwargs = Dict({}, config=True, help="Additional args to pass for container start")
+    extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")
+    extra_start_kwargs = Dict(config=True, help="Additional args to pass for container start")
 
     @property
     def tls_client(self):
@@ -218,7 +218,8 @@ class DockerSpawner(Spawner):
         self.container_id = ''
     
     @gen.coroutine
-    def start(self, image=None, extra_create_kwargs={}, extra_start_kwargs={}):
+    def start(self, image=None, extra_create_kwargs=None,
+        extra_start_kwargs=None):
         """Start the single-user server in a docker container. You can override
         the default parameters passed to `create_container` through the
         `extra_create_kwargs` dictionary and passed to `start` through the
@@ -239,7 +240,8 @@ class DockerSpawner(Spawner):
                 volumes=self.volume_mount_points,
                 name=self.container_name)
             create_kwargs.update(self.extra_create_kwargs)
-            create_kwargs.update(extra_create_kwargs)
+            if extra_create_kwargs:
+                create_kwargs.update(extra_create_kwargs)
 
             # create the container
             resp = yield self.docker('create_container', **create_kwargs)
@@ -263,7 +265,8 @@ class DockerSpawner(Spawner):
             binds=self.volume_binds,
             port_bindings={8888: (self.container_ip,)})
         start_kwargs.update(self.extra_start_kwargs)
-        start_kwargs.update(extra_start_kwargs)
+        if extra_start_kwargs:
+            start_kwargs.update(extra_start_kwargs)
 
         # start the container
         yield self.docker('start', self.container_id, **start_kwargs)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -260,7 +260,7 @@ class DockerSpawner(Spawner):
         start_kwargs.update(self.extra_start_kwargs)
 
         # start the container
-        resp = yield self.docker('start', self.container_id, **start_kwargs)
+        yield self.docker('start', self.container_id, **start_kwargs)
 
         # get the public-facing port
         resp = yield self.docker('port', self.container_id, 8888)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -218,10 +218,14 @@ class DockerSpawner(Spawner):
         self.container_id = ''
     
     @gen.coroutine
-    def start(self, image=None):
+    def start(self, image=None, extra_create_kwargs={}, extra_start_kwargs={}):
         """Start the single-user server in a docker container. You can override
         the default parameters passed to `create_container` through the
-        `extra_create_kwargs` dictionary.
+        `extra_create_kwargs` dictionary and passed to `start` through the
+        `extra_start_kwargs` dictionary.
+
+        Per-instance `extra_create_kwargs` and `extra_start_kwargs` takes
+        precedence over their global counterparts.
 
         """
         container = yield self.get_container()
@@ -235,6 +239,7 @@ class DockerSpawner(Spawner):
                 volumes=self.volume_mount_points,
                 name=self.container_name)
             create_kwargs.update(self.extra_create_kwargs)
+            create_kwargs.update(extra_create_kwargs)
 
             # create the container
             resp = yield self.docker('create_container', **create_kwargs)
@@ -258,6 +263,7 @@ class DockerSpawner(Spawner):
             binds=self.volume_binds,
             port_bindings={8888: (self.container_ip,)})
         start_kwargs.update(self.extra_start_kwargs)
+        start_kwargs.update(extra_start_kwargs)
 
         # start the container
         yield self.docker('start', self.container_id, **start_kwargs)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -253,13 +253,16 @@ class DockerSpawner(Spawner):
             "Starting container '%s' (id: %s)",
             self.container_name, self.container_id[:7])
 
+        # build the dictionary of keyword arguments for start
         start_kwargs = dict(
             binds=self.volume_binds,
             port_bindings={8888: (self.container_ip,)})
         start_kwargs.update(self.extra_start_kwargs)
 
+        # start the container
         resp = yield self.docker('start', self.container_id, **start_kwargs)
-        self.log.debug("Start Container:", resp)
+
+        # get the public-facing port
         resp = yield self.docker('port', self.container_id, 8888)
         self.user.server.port = resp[0]['HostPort']
 

--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -120,5 +120,5 @@ class SystemUserSpawner(DockerSpawner):
         """start the single-user server in a docker container"""
         yield super(SystemUserSpawner, self).start(
             image=image,
-            working_dir=self.homedir
+            extra_create_kwargs={'working_dir': self.homedir}
         )


### PR DESCRIPTION
Support both create_container and start optional args. Made args configurable, so you do not have to extend DockerSpawner to just change the args.