### PR TITLE
Allow use of usernames in volume paths

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -69,6 +69,8 @@ class DockerSpawner(Spawner):
             """
             Map from host file/directory to container file/directory.
             Volumes specified here will be read/write in the container.
+            If you use {username} in the host file / directory path, it will be
+            replaced with the current user's name.
             """
         )
     )
@@ -78,6 +80,8 @@ class DockerSpawner(Spawner):
             """
             Map from host file/directory to container file/directory.
             Volumes specified here will be read-only in the container.
+            If you use {username} in the host file / directory path, it will be
+            replaced with the current user's name.
             """
         )
     )
@@ -131,11 +135,11 @@ class DockerSpawner(Spawner):
         }
         """
         volumes = {
-            key: {'bind': value, 'ro': False}
+            key.format(username=self.user.name): {'bind': value, 'ro': False}
             for key, value in self.volumes.items()
         }
         ro_volumes = {
-            key: {'bind': value, 'ro': True}
+            key.format(username=self.user.name): {'bind': value, 'ro': True}
             for key, value in self.read_only_volumes.items()
         }
         volumes.update(ro_volumes)


### PR DESCRIPTION
This allows us to give each docker instance a different 'home' 
somewhere on shared storage on the host, thus making it persistant.
