### PR TITLE
Allow specifying Hub IP for containers to communicate.

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -92,6 +92,19 @@ class DockerSpawner(Spawner):
     extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")
     extra_start_kwargs = Dict(config=True, help="Additional args to pass for container start")
 
+    hub_api_url = Unicode(
+        "",
+        config=True,
+        help=dedent(
+            """
+            If set, DockerSpawner will configure the containers to use
+            the specified URL instead of 'self.hub.api_url'.  This is
+            useful when the hub_api is bound to listen on all ports or
+            is running inisde of a container.
+            """
+        )
+    )
+
     @property
     def tls_client(self):
         """A tuple consisting of the TLS client certificate and key if they
@@ -165,9 +178,12 @@ class DockerSpawner(Spawner):
             JPY_USER=self.user.name,
             JPY_COOKIE_NAME=self.user.server.cookie_name,
             JPY_BASE_URL=self.user.server.base_url,
-            JPY_HUB_PREFIX=self.hub.server.base_url,
-            JPY_HUB_API_URL=self.hub.api_url,
+            JPY_HUB_PREFIX=self.hub.server.base_url
         ))
+        if self.hub_api_url:
+           env.update(dict(JPY_HUB_API_URL=self.hub_api_url))
+        else:
+           env.update(dict(JPY_HUB_API_URL=self.hub.api_url))
         return env
 
     def _docker(self, method, *args, **kwargs):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -92,15 +92,15 @@ class DockerSpawner(Spawner):
     extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")
     extra_start_kwargs = Dict(config=True, help="Additional args to pass for container start")
 
-    hub_api_url = Unicode(
+    hub_ip_connect = Unicode(
         "",
         config=True,
         help=dedent(
             """
             If set, DockerSpawner will configure the containers to use
-            the specified URL instead of 'self.hub.api_url'.  This is
-            useful when the hub_api is bound to listen on all ports or
-            is running inisde of a container.
+            the specified IP to connect the hub api.  This is useful
+            when the hub_api is bound to listen on all ports or is
+            running inisde of a container.
             """
         )
     )
@@ -167,7 +167,16 @@ class DockerSpawner(Spawner):
         if self.container_id:
             state['container_id'] = self.container_id
         return state
-    
+
+    def _public_hub_api_url(self):
+        proto, rest = self.hub.api_url.split('://', 1)
+        ip, rest = path.split(':', 1)
+        return '{proto}://{ip}:{rest}'.format(
+            proto = proto,
+            ip = self.hub_ip_connect,
+            rest = rest
+        )
+
     def _env_keep_default(self):
         """Don't inherit any env from the parent process"""
         return []
@@ -180,8 +189,8 @@ class DockerSpawner(Spawner):
             JPY_BASE_URL=self.user.server.base_url,
             JPY_HUB_PREFIX=self.hub.server.base_url
         ))
-        if self.hub_api_url:
-           env.update(dict(JPY_HUB_API_URL=self.hub_api_url))
+        if self.hub_ip_connect:
+           env.update(dict(JPY_HUB_API_URL=self._public_hub_api_url()))
         else:
            env.update(dict(JPY_HUB_API_URL=self.hub.api_url))
         return env

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -169,7 +169,7 @@ class DockerSpawner(Spawner):
         return state
 
     def _public_hub_api_url(self):
-        proto, rest = self.hub.api_url.split('://', 1)
+        proto, path = self.hub.api_url.split('://', 1)
         ip, rest = path.split(':', 1)
         return '{proto}://{ip}:{rest}'.format(
             proto = proto,

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -100,7 +100,7 @@ class DockerSpawner(Spawner):
             If set, DockerSpawner will configure the containers to use
             the specified IP to connect the hub api.  This is useful
             when the hub_api is bound to listen on all ports or is
-            running inisde of a container.
+            running inside of a container.
             """
         )
     )
@@ -189,10 +189,13 @@ class DockerSpawner(Spawner):
             JPY_BASE_URL=self.user.server.base_url,
             JPY_HUB_PREFIX=self.hub.server.base_url
         ))
+
         if self.hub_ip_connect:
-           env.update(dict(JPY_HUB_API_URL=self._public_hub_api_url()))
+           hub_api_url = self._public_hub_api_url()
         else:
-           env.update(dict(JPY_HUB_API_URL=self.hub.api_url))
+           hub_api_url = self.hub.api_url
+        env['JPY_HUB_API_URL'] = self.hub.api_url
+
         return env
 
     def _docker(self, method, *args, **kwargs):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -194,7 +194,7 @@ class DockerSpawner(Spawner):
            hub_api_url = self._public_hub_api_url()
         else:
            hub_api_url = self.hub.api_url
-        env['JPY_HUB_API_URL'] = self.hub.api_url
+        env['JPY_HUB_API_URL'] = hub_api_url
 
         return env
 


### PR DESCRIPTION
This is useful when the IP the hub is bound on is not directly reachable by the containers.  When the config option is not set, `Hub.ip` is used.