### PR TITLE
Use standalone traitlets

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -13,7 +13,7 @@ from docker.utils import create_host_config
 from tornado import gen
 
 from jupyterhub.spawner import Spawner
-from IPython.utils.traitlets import (
+from traitlets import (
     Dict,
     Unicode,
     Bool

--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -2,7 +2,7 @@ import pwd
 
 from dockerspawner import DockerSpawner
 from textwrap import dedent
-from IPython.utils.traitlets import (
+from traitlets import (
     Integer,
     Unicode,
 )


### PR DESCRIPTION
jupyter/jupyterhub#261 removes the dependency on IPython.utils.traitlets. This PR uses the standalone traitlets directly.