### PR TITLE
escape username in container name

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -161,14 +161,19 @@ class DockerSpawner(Spawner):
         volumes.update(ro_volumes)
         return volumes
 
+    _escaped_name = None
     @property
-    def container_name(self):
-        return "{}-{}".format(self.container_prefix,
-            escape(self.user.name,
+    def escaped_name(self):
+        if self._escaped_name is None:
+            self._escaped_name = escape(self.user.name,
                 safe=self._container_safe_chars,
                 escape_char=self._container_escape_char,
             )
-        )
+        return self._escaped_name
+
+    @property
+    def container_name(self):
+        return "{}-{}".format(self.container_prefix, self.escaped_name)
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
--e git+https://github.com/jupyter/jupyterhub.git#egg=jupyterhub
-ipython[notebook]
+jupyterhub
+escapism
 docker-py


### PR DESCRIPTION
only allow `[A-Za-z0-9_-]`, escape everything else.

cf [docker container name spec](https://github.com/ajhager/docker/commit/f63cdf0260cf6287d28a589a79d3f947def6a569)

closes #25
closes #39