### PR TITLE
Add option to toggle hostname assertion with TLS

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -44,7 +44,8 @@ class DockerSpawner(Spawner):
                 tls_config = docker.tls.TLSConfig(
                     client_cert=self.tls_client,
                     ca_cert=self.tls_ca,
-                    verify=self.tls_verify)
+                    verify=self.tls_verify,
+                    assert_hostname=self.tls_assert_hostname)
             else:
                 tls_config = None
 
@@ -90,6 +91,7 @@ class DockerSpawner(Spawner):
     tls_ca = Unicode("", config=True, help="Path to CA certificate for docker TLS")
     tls_cert = Unicode("", config=True, help="Path to client certificate for docker TLS")
     tls_key = Unicode("", config=True, help="Path to client key for docker TLS")
+    tls_assert_hostname = Bool(True, config=True, help="If False, do not verify hostname of docker daemon")
 
     remove_containers = Bool(False, config=True, help="If True, delete containers after they are stopped.")
     extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")


### PR DESCRIPTION
When using TLS, sometimes the certs don't exactly match the hostname where the docker daemon is running. For example, the cert might be for `*` but docker-py will complain if `assert_hostname` is true (which is the default) because `*` is not the same as the actual hostname.

I don't think the docker command line client actually does this assertion, because accessing the docker daemon via the command line with TLS works fine, it's just through docker-py that it doesn't by default (but it does when the assertion is disabled).