### PR TITLE
MAINT: tls_assert_hostname should be either a string or False

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -18,8 +18,11 @@ from jupyterhub.spawner import Spawner
 from traitlets import (
     Dict,
     Unicode,
-    Bool
+    Bool,
+    Union,
+    Enum,
 )
+
 
 class DockerSpawner(Spawner):
     
@@ -99,7 +102,9 @@ class DockerSpawner(Spawner):
     tls_ca = Unicode("", config=True, help="Path to CA certificate for docker TLS")
     tls_cert = Unicode("", config=True, help="Path to client certificate for docker TLS")
     tls_key = Unicode("", config=True, help="Path to client key for docker TLS")
-    tls_assert_hostname = Bool(True, config=True, help="If False, do not verify hostname of docker daemon")
+    tls_assert_hostname = Union([Unicode(None, allow_none=True, config=True,
+                                         help="If False, do not verify hostname of docker daemon"),
+                                 Enum([False])])
 
     remove_containers = Bool(False, config=True, help="If True, delete containers after they are stopped.")
     extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")


### PR DESCRIPTION
according to [urllib3] (https://urllib3.readthedocs.org/en/latest/pools.html#urllib3.connectionpool.HTTPSConnectionPool):  "VerifiedHTTPSConnection uses one of assert_fingerprint, assert_hostname and host in this order to verify connections. If assert_hostname is False, no verification is done."

With the current default value of `True`, I get an AttributeError when urllib3 tries to call `lower` on `True` in order to compare it to another string:
```
      File "/Users/rich/.virtualenvs/research_env/lib/python3.4/site-packages/requests/packages/urllib3/connection.py", line 253, in connect
        match_hostname(cert, self.assert_hostname or hostname)
      File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/ssl.py", line 268, in match_hostname
        if _dnsname_match(value, hostname):
      File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/ssl.py", line 225, in _dnsname_match
        return dn.lower() == hostname.lower()
    AttributeError: 'bool' object has no attribute 'lower'
```