### PR TITLE
install oauthenticator in oauth example

### DIFF
--- a/examples/oauth/README.md
+++ b/examples/oauth/README.md
@@ -11,6 +11,11 @@ spinning up a [docker](https://www.docker.com/) container for each user.
 
 (I assume you have installed dockerspawner dependencies and built the single-user container already)
 
+Install oauthenticator:
+
+    pip install git+https://github.com/jupyter/oauthenticator.git
+
+
 Make a file called `userlist` with one GitHub user name per line.
 If that user should be an admin (you!), add `admin` after a space.
 
@@ -41,7 +46,7 @@ To run the server on HTTPS, put your ssl key and cert in ssl/ssl.key and ssl/ssl
 
 You can run the server with:
 
-    sh run.sh
+    bash run.sh
 
 Which will run the JupyterHub server, loading your GitHub credentials from `env`.
 When users login, a container will be created for them. Like magic!

--- a/examples/oauth/run.sh
+++ b/examples/oauth/run.sh
@@ -1,7 +1,7 @@
-here="$(dirname $0)"
-export PYTHONPATH="$here:$here/../..:$PYTHONPATH"
+#!/usr/bin/env bash
 
-test -f oauthenticator.py || curl https://raw.githubusercontent.com/jupyter/oauthenticator/master/oauthenticator.py > oauthenticator.py
+here="$(dirname $0)"
+
 # load github auth from env
 source $here/env
 


### PR DESCRIPTION
Example is from when oauthenticator was a single file, not an installable package.

cc @RafalSkolasinski