### PR TITLE
use jupyter/scipy-notebook as single-user base image

### DIFF
--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -1,28 +1,13 @@
 # Build as jupyter/jupyterhub-singleuser
 # Run with the DockerSpawner in JupyterHub
 
-FROM ipython/scipystack
+FROM jupyter/scipy-notebook
 
-MAINTAINER IPython Project <ipython-dev@scipy.org>
+MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 # fetch juptyerhub-singleuser entrypoint
 ADD https://raw.githubusercontent.com/jupyter/jupyterhub/master/jupyterhub/singleuser.py /usr/local/bin/jupyterhub-singleuser
 RUN chmod 755 /usr/local/bin/jupyterhub-singleuser
-
-# jupyter is our user
-RUN useradd -m -s /bin/bash jupyter
-
-USER jupyter
-ENV HOME /home/jupyter
-ENV SHELL /bin/bash
-ENV USER jupyter
-
-WORKDIR /home/jupyter/
-
-# IPython introductions
-RUN cp -r /srv/ipython/examples /home/jupyter/examples
-
-EXPOSE 8888
 
 ADD singleuser.sh /srv/singleuser/singleuser.sh
 CMD ["sh", "/srv/singleuser/singleuser.sh"]

--- a/singleuser/README.md
+++ b/singleuser/README.md
@@ -1,6 +1,6 @@
 # jupyter/singleuser
 
-Built from the `ipython/scipystack` base image.
+Built from the `jupyter/scipy-notebook` base image.
 
 This image contains a single user notebook server for use with
 [JupyterHub](https://github.com/jupyter/jupyterhub). In particular, it is meant

--- a/systemuser/Dockerfile
+++ b/systemuser/Dockerfile
@@ -1,7 +1,7 @@
 # Build as jupyter/systemuser
 # Run with the DockerSpawner in JupyterHub
 
-FROM ipython/scipystack
+FROM jupyter/scipy-notebook
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 

--- a/systemuser/README.md
+++ b/systemuser/README.md
@@ -1,6 +1,6 @@
 # jupyter/systemuser
 
-Built from the `ipython/scipystack` base image.
+Built from the `jupyter/scipy-notebook` base image.
 
 This image contains a single user notebook server for use with
 [JupyterHub](https://github.com/jupyter/jupyterhub). In particular, it is meant


### PR DESCRIPTION
instead of deprecated ipython/scipystack

closes #55