### PR TITLE
Allow usage of internal docker subnet IP

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -336,9 +336,9 @@ class DockerSpawner(Spawner):
                 create_kwargs.update(extra_create_kwargs)
 
             # build the dictionary of keyword arguments for host_config
-            host_config = dict(
-                binds=self.volume_binds,
-                port_bindings={8888: (self.container_ip,)})
+            host_config = dict(binds=self.volume_binds)
+            if not self.use_internal_ip:
+                host_config['port_bindings'] = {8888: (self.container_ip,)}
             host_config.update(self.extra_host_config)
             if extra_host_config:
                 host_config.update(extra_host_config)


### PR DESCRIPTION
The context for this proposed change is, that I want to be able to use internal docker IP addresses instead of the public ones. I am running the jupyterhub server (as docker container) and the user containers on the same docker engine which is enough for smaller scenarios without a swarm. If I use the code as it is the public ip/port  of the spawned user container is used (localhost and random unprivileged port). These changes add the possibility to use the internal IP instead and (since it is not required in that case) do not expose a port to the outside.