### PR TITLE
more dockerfile updates

### DIFF
--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -5,11 +5,15 @@ FROM jupyter/scipy-notebook
 
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
+EXPOSE 8888
+
 USER root
 # fetch juptyerhub-singleuser entrypoint
-ADD https://raw.githubusercontent.com/jupyter/jupyterhub/master/jupyterhub/singleuser.py /usr/local/bin/jupyterhub-singleuser
-RUN chmod 755 /usr/local/bin/jupyterhub-singleuser
+RUN wget -q https://raw.githubusercontent.com/jupyter/jupyterhub/master/scripts/jupyterhub-singleuser -O /usr/local/bin/jupyterhub-singleuser && \
+    chmod 755 /usr/local/bin/jupyterhub-singleuser
 
 ADD singleuser.sh /srv/singleuser/singleuser.sh
 USER jovyan
+# smoke test that it's importable at least
+RUN sh /srv/singleuser/singleuser.sh -h
 CMD ["sh", "/srv/singleuser/singleuser.sh"]

--- a/singleuser/singleuser.sh
+++ b/singleuser/singleuser.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+set -e
 exec jupyterhub-singleuser \
   --port=8888 \
   --ip=0.0.0.0 \
@@ -7,6 +7,7 @@ exec jupyterhub-singleuser \
   --cookie-name=$JPY_COOKIE_NAME \
   --base-url=$JPY_BASE_URL \
   --hub-prefix=$JPY_HUB_PREFIX \
-  --hub-api-url=$JPY_HUB_API_URL
+  --hub-api-url=$JPY_HUB_API_URL \
+  $@
 
     

--- a/systemuser/Dockerfile
+++ b/systemuser/Dockerfile
@@ -1,19 +1,14 @@
 # Build as jupyter/systemuser
 # Run with the DockerSpawner in JupyterHub
 
-FROM jupyter/scipy-notebook
+FROM jupyter/singleuser
 
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
-# fetch juptyerhub-singleuser entrypoint
 USER root
-ADD https://raw.githubusercontent.com/jupyter/jupyterhub/master/jupyterhub/singleuser.py /usr/local/bin/jupyterhub-singleuser
-RUN chmod 755 /usr/local/bin/jupyterhub-singleuser
-
-EXPOSE 8888
-
 ENV SHELL /bin/bash
-
 ADD systemuser.sh /srv/singleuser/systemuser.sh
+# smoke test entrypoint
+RUN USER_ID=65000 USER=systemusertest sh /srv/singleuser/systemuser.sh -h && userdel systemusertest
 
 CMD ["sh", "/srv/singleuser/systemuser.sh"]

--- a/systemuser/systemuser.sh
+++ b/systemuser/systemuser.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+set -e
 echo "Creating user $USER ($USER_ID)"
 useradd -u $USER_ID -s $SHELL $USER
 sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
@@ -9,5 +9,6 @@ sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
   --cookie-name=$JPY_COOKIE_NAME \
   --base-url=$JPY_BASE_URL \
   --hub-prefix=$JPY_HUB_PREFIX \
-  --hub-api-url=$JPY_HUB_API_URL
+  --hub-api-url=$JPY_HUB_API_URL \
+  $@
 


### PR DESCRIPTION
- get jupyterhub-singleuser script from its new home
- smoke test entrypoints to ensure they can at least produce help output
- base system user image on singleuser to reduce duplication