### PR TITLE
Use HostIp from docker port output

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -422,7 +422,7 @@ class DockerSpawner(Spawner):
             port = 8888
         else:
             resp = yield self.docker('port', self.container_id, 8888)
-            ip = self.container_ip
+            ip = resp[0]['HostIp']
             port = resp[0]['HostPort']
         return ip, port
 


### PR DESCRIPTION
Rather than use `container_ip` from the DockerSpawner configuration, use the IP address reported by the `docker port` command. This should behave identically when `container_ip` is left at its default or specified explicitly, because Docker will report the IP that was bound. But, by using `container_ip` as the interface to bind and reading the read address from Docker after container launch, users can specify:

```python
c.DockerSpawner.container_ip = "0.0.0.0"
```

And JupyterHub will connect to the launched container at its public IP.

With only this change, I was able to use the regular `DockerSpawner` to run JupyterHub on Swarm, with user containers launching on different nodes. :confetti_ball: 