### PR TITLE
[WIP] Return None even if container does not exist

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -301,7 +301,7 @@ class DockerSpawner(Spawner):
         container = yield self.get_container()
         if not container:
             self.log.warn("container not found")
-            return ""
+            return None 
 
         container_state = container['State']
         self.log.debug(


### PR DESCRIPTION
This follows on from jupyter/jupyterhub#428. There are cases when the container is still being created by `start()` and `poll()` is being called, in which case `jupyterhub` decides that things went wrong.

As a starting point I suggest to return `None` even if the container doesn't exist. This is probably not the best solution though as the container might not exist because it got killed. How to best handle the difference between "container has never existed so might still be being created" and "container used to exist, but not anymore -> exited"?