### PR TITLE
Forget container id if node is unhealthy

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -333,6 +333,11 @@ class DockerSpawner(Spawner):
                 container = None
                 # my container is gone, forget my id
                 self.container_id = ''
+            elif e.response.status_code == 500:
+                self.log.info("Container '%s' is on unhealthy node", self.container_name)
+                container = None
+                # my container is unhealthy, forget my id
+                self.container_id = ''
             else:
                 raise
         return container


### PR DESCRIPTION
To address:
    docker.errors.APIError: 500 Server Error: Internal Server Error ("b'Container jupyter-USER running on unhealthy node NODE'")