### PR TITLE
revert to "yeild from" to work with swarm

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -412,7 +412,7 @@ class DockerSpawner(Spawner):
         # start the container
         yield self.docker('start', self.container_id, **start_kwargs)
 
-        ip, port = yield self.get_ip_and_port()
+        ip, port = yield from self.get_ip_and_port()
         self.user.server.ip = ip
         self.user.server.port = port
 


### PR DESCRIPTION
Is there a particular reason why `yield from` was changed to `yield` in a535b08? With the latest master, I get the following error when I use dockerspawner with Swarm.

```
[E 2016-02-23 01:53:43.647 JupyterHub web:1524] Uncaught exception GET /hub/user/EdwardJKim (192.168.0.10)
    HTTPServerRequest(protocol='http', host='129.114.110.10', method='GET', uri='/hub/user/EdwardJKim', version='HTTP/1.1', remote_ip='192.168.0.10', headers={'X-Forwarded-Host': '129.114.110.10', 'Remote-User': '(null)', 'Accept-Language': 'en-US,en;q=0.8,ko;q=0.6', 'X-Forwarded-For': '192.241.58.150,192.168.0.10', 'Host': '129.114.110.10', 'Referer': 'https://129.114.110.10/hub/home', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', 'Accept-Encoding': 'gzip, deflate, sdch', 'Cookie': 'jupyter-hub-token="2|1:0|10:1456192417|17:jupyter-hub-token|44:NWRmMDY3ZmNmODI3NGNiOWEzMjUxYzk5ZDNmYTc2Nzc=|4bb0a324e2ef35d695841219516c32d9c60c06df5b134313fe4d75810e185f96"', 'Connection': 'close', 'X-Forwarded-Proto': 'http', 'User-Agent': 'Mozilla/5.0 (X11; CrOS x86_64 7647.84.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36', 'X-Forwarded-Port': '80', 'X-Forwarded-Server': '129.114.110.10', 'Upgrade-Insecure-Requests': '1'})
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.5/site-packages/tornado/web.py", line 1445, in _execute
        result = yield result
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 463, in get
        yield self.spawn_single_user(current_user)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 296, in spawn_single_user
        yield gen.with_timeout(timedelta(seconds=self.slow_spawn_timeout), f)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/user.py", line 202, in spawn
        raise e
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/user.py", line 183, in spawn
        self.log.info(info)
        yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
      File "/srv/jupyterhub_config/swarmspawner.py", line 65, in start
        extra_host_config=extra_host_config)
      File "/opt/conda/lib/python3.5/site-packages/dockerspawner/dockerspawner.py", line 415, in start
        ip, port = yield self.get_ip_and_port()
      File "/opt/conda/lib/python3.5/site-packages/tornado/gen.py", line 1090, in handle_yield
        self.future = convert_yielded(yielded)
      File "/opt/conda/lib/python3.5/functools.py", line 743, in wrapper
        return dispatch(args[0].__class__)(*args, **kw)
      File "/opt/conda/lib/python3.5/site-packages/tornado/gen.py", line 1222, in convert_yielded
        raise BadYieldError("yielded unknown object %r" % (yielded,))
    tornado.gen.BadYieldError: yielded unknown object <generator object DockerSpawner.get_ip_and_port at 0x7f44d8502258>
```

Reverting to `yield from` fixes the error.