### PR TITLE
Skip useradd if the user exists

### DIFF
--- a/systemuser/systemuser.sh
+++ b/systemuser/systemuser.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -e
-echo "Creating user $USER ($USER_ID)"
-useradd -u $USER_ID -s $SHELL $USER
+if getent passwd $USER_ID > /dev/null ; then
+  echo "$USER ($USER_ID) exists"
+else
+  echo "Creating user $USER ($USER_ID)"
+  useradd -u $USER_ID -s $SHELL $USER
+fi
 sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
   --port=8888 \
   --ip=0.0.0.0 \
@@ -11,4 +15,3 @@ sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
   --hub-prefix=$JPY_HUB_PREFIX \
   --hub-api-url=$JPY_HUB_API_URL \
   $@
-


### PR DESCRIPTION
If the user exists and DockerSpawner.remove_containers is not set, this script will exit immediately (-e) and the user's container won't start. data-8 is running into this. Also described at https://github.com/jupyter/dockerspawner/issues/67#issuecomment-179557330.