### PR TITLE
Added support for specifying notebook_dir of spawned container

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -156,9 +156,9 @@ class DockerSpawner(Spawner):
         help=dedent(
             """
             Specify docker link mapping to add to the container, e.g.
-            
+
                 links = {'jupyterhub: 'jupyterhub'}
-            
+
             If the Hub is running in a Docker container,
             this can simplify routing because all traffic will be using docker hostnames.
             """
@@ -271,6 +271,9 @@ class DockerSpawner(Spawner):
             JPY_BASE_URL=self.user.server.base_url,
             JPY_HUB_PREFIX=self.hub.server.base_url
         ))
+
+        if self.notebook_dir:
+            env['NOTEBOOK_DIR'] = self.notebook_dir
 
         if self.hub_ip_connect:
            hub_api_url = self._public_hub_api_url()

--- a/singleuser/singleuser.sh
+++ b/singleuser/singleuser.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 set -e
+
+notebook_arg=""
+if [ -n "${NOTEBOOK_DIR:+x}" ]
+then
+    notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
+fi
+
 exec jupyterhub-singleuser \
   --port=8888 \
   --ip=0.0.0.0 \
@@ -8,6 +15,5 @@ exec jupyterhub-singleuser \
   --base-url=$JPY_BASE_URL \
   --hub-prefix=$JPY_HUB_PREFIX \
   --hub-api-url=$JPY_HUB_API_URL \
+  ${notebook_arg} \
   $@
-
-    

--- a/systemuser/systemuser.sh
+++ b/systemuser/systemuser.sh
@@ -6,6 +6,13 @@ else
   echo "Creating user $USER ($USER_ID)"
   useradd -u $USER_ID -s $SHELL $USER
 fi
+
+notebook_arg=""
+if [ -n "${NOTEBOOK_DIR:+x}" ]
+then
+    notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
+fi
+
 sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
   --port=8888 \
   --ip=0.0.0.0 \
@@ -14,4 +21,5 @@ sudo -E PATH="${CONDA_DIR}/bin:$PATH" -u $USER jupyterhub-singleuser \
   --base-url=$JPY_BASE_URL \
   --hub-prefix=$JPY_HUB_PREFIX \
   --hub-api-url=$JPY_HUB_API_URL \
+  ${notebook_arg} \
   $@


### PR DESCRIPTION
Following my conversation with @minrk, i added the `--notebook-dir` flag to the spawning bash script with a little bash magic for optionally applying it. 