### PR TITLE
Extend get_env instead of _env_default in systemuserspawner.py.

### DIFF
--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -98,8 +98,8 @@ class SystemUserSpawner(DockerSpawner):
         }
         return volumes
 
-    def _env_default(self):
-        env = super(SystemUserSpawner, self)._env_default()
+    def get_env(self):
+        env = super(SystemUserSpawner, self).get_env()
         env.update(dict(
             USER=self.user.name,
             USER_ID=self.user_id,


### PR DESCRIPTION
This will match the DockerSpawner parent class and prevent an AttributeError since _env_default is no longer defined in the parent since PR #84.

```
File "/opt/conda/lib/python3.5/site-packages/dockerspawner/systemuserspawner.py", line 102, in _env_default
   env = super(SystemUserSpawner, self)._env_default()
AttributeError: 'super' object has no attribute '_env_default'
```